### PR TITLE
tweaks and tests to treat false as not nil

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject zip-visit "1.0.0"
+(defproject zip-visit "1.0.1"
   :description "Clojure zipper-based visitor library."
   :url "https://github.com/akhudek/zip-visit"
   :license {:name "MIT"

--- a/src/zip/visit.clj
+++ b/src/zip/visit.clj
@@ -11,15 +11,17 @@
       (let [{node* :node state* :state b :break c :cut} (v dir node state)]
         (if (or b c)
           {:node node* :state state* :break b :cut c}
-          (recur (or node* node) (or state* state) visitors)))
+          (recur (if (nil? node*) node node*)
+                 (if (nil? state*) state state*)
+                 visitors)))
       {:node node :state state})))
 
 (defn- visit-location
   [dir loc state visitors]
   (let [node (z/node loc)
         context (visit-node dir (z/node loc) state visitors)]
-    {:loc   (if-let [new-node (:node context)] (z/replace loc new-node) loc)
-     :state (or (:state context) state)
+    {:loc   (if (nil? (:node context)) loc (z/replace loc (:node context)))
+     :state (if (nil? (:state context)) state (:state context))
      :break (:break context)
      :cut   (:cut context)}))
 

--- a/test/zip/visit_test.clj
+++ b/test/zip/visit_test.clj
@@ -1,7 +1,41 @@
 (ns zip.visit-test
-  (:require [clojure.test :refer :all]
-            [zip.visit :refer :all]))
+  (:require
+   [clojure.test :refer :all]
+   [clojure.zip]
+   [zip.visit]
+   )
+  )
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+
+(defn- -xor [a b] (and (or a b) (not (and a b))))
+
+
+(deftest false-is-not-nil
+
+  (testing "false node propagation"
+
+    (is (= {:node [false true true false true true], :state nil}
+           (zip.visit/visit
+            (clojure.zip/vector-zip [0 1 1 2 3 5])
+            nil
+            [(zip.visit/visitor
+              :pre [n s]
+              (if (number? n) {:node (odd? n)}))])
+           )
+        )
+    )
+
+  (testing "false state propagation"
+
+    (is (= {:node [0 1 1 2 3 5],
+            :state (reduce -xor false [0 1 1 2 3 5])}
+           (zip.visit/visit
+            (clojure.zip/vector-zip [0 1 1 2 3 5])
+            false
+            [(zip.visit/visitor
+              :pre [n s]
+              (if (number? n) {:state (-xor s (odd? n))}))])
+           )
+        )
+    )
+  )


### PR DESCRIPTION
this change allows the propagation of false nodes and states. Previously, they were conflated with nil, and as a result, were not propagated between visitations
